### PR TITLE
Fix typo in the usage description

### DIFF
--- a/Sources/xcprojectlint-package/Validation.swift
+++ b/Sources/xcprojectlint-package/Validation.swift
@@ -44,7 +44,7 @@ List of validations to perform:
                        Validates files on disk are arranged like the project
                        file
 
-                     empty_groups:
+                     empty-groups:
                        Reports groups that have no children
 
                      files-exist-on-disk:


### PR DESCRIPTION
This PR fixes the following issue:

`xcprojectlint --help` mentions "empty_groups" as a valid validation.
This is not true:
```
$ xcprojectlint --report error --project [...].xcodeproj --validations empty_groups
unknown value 'empty_groups' for argument --validations; use --help to print usage
```
It should be `empty-groups`.