### PR TITLE
Linux support

### DIFF
--- a/Sources/xcprojectlint-package/CheckForInternalProjectSettings.swift
+++ b/Sources/xcprojectlint-package/CheckForInternalProjectSettings.swift
@@ -36,7 +36,7 @@ public func checkForInternalProjectSettings(_ project: Project, errorReporter: E
     // see if we can find the buildSettings node closest to this build configuration
     var currentLine = 0
     var foundKey = false
-    project.projectText.enumerateLines(invoking: { (line, stop) in
+    for line in project.projectText.components(separatedBy: CharacterSet.newlines) {
       currentLine += 1
       if !foundKey {
         if line.contains(buildConfiguration.id) {
@@ -44,10 +44,10 @@ public func checkForInternalProjectSettings(_ project: Project, errorReporter: E
         }
       } else {
         if line.contains("buildSettings") {
-          stop = true
+          break
         }
       }
-    })
+    }
     
     let errStr: String!
     // NOTE: The spaces around the error: portion of the string are required with Xcode 8.3. Without them, no output gets reported in the Issue Navigator.

--- a/Sources/xcprojectlint-package/CheckForInternalProjectSettings.swift
+++ b/Sources/xcprojectlint-package/CheckForInternalProjectSettings.swift
@@ -12,7 +12,6 @@
  * the License.
  */
 
-import Darwin
 import Foundation
 
 public func checkForInternalProjectSettings(_ project: Project, errorReporter: ErrorReporter) -> Int32 {

--- a/Sources/xcprojectlint-package/DiskLayoutMatchesProject.swift
+++ b/Sources/xcprojectlint-package/DiskLayoutMatchesProject.swift
@@ -12,7 +12,6 @@
  * the License.
  */
 
-import Darwin
 import Foundation
 
 private func recurseForMisplacedFiles(_ groups: [String], project: Project, errors: Set<String>, errorReporter: ErrorReporter) -> Set<String> {

--- a/Sources/xcprojectlint-package/EnsureAlphaOrder.swift
+++ b/Sources/xcprojectlint-package/EnsureAlphaOrder.swift
@@ -12,7 +12,6 @@
  * the License.
  */
 
-import Darwin
 import Foundation
 
 private func validateThisGroup(_ id: String, title: String, project: Project, errorReporter: ErrorReporter) -> Bool {

--- a/Sources/xcprojectlint-package/FilesExistOnDisk.swift
+++ b/Sources/xcprojectlint-package/FilesExistOnDisk.swift
@@ -12,7 +12,6 @@
  * the License.
  */
 
-import Darwin
 import Foundation
 
 private func recurseForMissingFiles(_ groups: [String], hierarchy: [String], project: Project, errors: Set<String>, errorReporter: ErrorReporter) -> Set<String> {

--- a/Sources/xcprojectlint-package/NoEmptyGroups.swift
+++ b/Sources/xcprojectlint-package/NoEmptyGroups.swift
@@ -12,7 +12,6 @@
  * the License.
  */
 
-import Darwin
 import Foundation
 
 private func validateThisGroup(_ id: String, title: String, project: Project, errorReporter: ErrorReporter) -> Bool {

--- a/Sources/xcprojectlint-package/Project.swift
+++ b/Sources/xcprojectlint-package/Project.swift
@@ -46,7 +46,7 @@ public struct Project {
     guard let projectText = String(data: data, encoding: .utf8) else { throw ProjectParseError.failedToInflateProjectFile }
     guard let serialization = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [AnyHashable : Any] else { throw ProjectParseError.failedToSerializeProjectData }
     guard let plist = serialization else { throw ProjectParseError.failedToSerializeProjectData }
-    guard let dict = NSDictionary(dictionary: plist) as? Dictionary<String, Any> else { throw ProjectParseError.failedToContortDictionary }
+    guard let dict = plist as? [String : Any] else { throw ProjectParseError.failedToContortDictionary }
     
     let parser = ProjectParser(project: dict, projectText: projectText, projectPath: projectPath)
     guard parser.parse() else { throw ProjectParseError.failedToParseProjectStructure }

--- a/Sources/xcprojectlint-package/ProjectParser.swift
+++ b/Sources/xcprojectlint-package/ProjectParser.swift
@@ -375,33 +375,32 @@ struct VariantGroup: CustomDebugStringConvertible {
 func extractBuildConfigurationTitles(_ projectText: String) -> Dictionary<String, String> {
   var titleMap = Dictionary<String, String>()
   var inBuildConfigsSection = false
-  projectText.enumerateLines(invoking: { (line, stop) in
+  for line in projectText.components(separatedBy: CharacterSet.newlines) {
     if !inBuildConfigsSection {
       if line.contains("XCBuildConfiguration section") {
         inBuildConfigsSection = true
       }
-      return
+      continue
     }
     
     // see if we're done
     if line.contains("XCBuildConfiguration section") {
-      stop = true
-      return
+      break
     }
     // we're in the build section, and not done, so pull apart the line
     var line = line.trimmingCharacters(in: .whitespaces)
     
     var splits = line.components(separatedBy: " /* ")
     if splits.count != 2 {
-      return
+      continue
     }
     let key = splits[0]
     line = splits[1]
     splits = line.components(separatedBy: " */")
-    if splits.count != 2 { return }
+    if splits.count != 2 { continue }
     let title = splits[0]
     titleMap[key] = title
-  })
+  }
   
   return titleMap
 }
@@ -411,33 +410,32 @@ func extractBuildConfigurationTitles(_ projectText: String) -> Dictionary<String
 func extractBuildConfigurationListTitles(_ projectText: String) -> Dictionary<String, String> {
   var titleMap = Dictionary<String, String>()
   var inBuildConfigsSection = false
-  projectText.enumerateLines(invoking: { (line, stop) in
+  for line in projectText.components(separatedBy: CharacterSet.newlines) {
     if !inBuildConfigsSection {
       if line.contains("XCConfigurationList section") {
         inBuildConfigsSection = true
       }
-      return
+      continue
     }
     
     // see if we're done
     if line.contains("XCConfigurationList section") {
-      stop = true
-      return
+      break
     }
     // we're in the build section, and not done, so pull apart the line
     var line = line.trimmingCharacters(in: .whitespaces)
     
     var splits = line.components(separatedBy: " /* ")
     if splits.count != 2 {
-      return
+      continue
     }
     let key = splits[0]
     line = splits[1]
     splits = line.components(separatedBy: " */")
-    if splits.count != 2 { return }
+    if splits.count != 2 { continue }
     let title = splits[0]
     titleMap[key] = title
-  })
+  }
   
   return titleMap
 }
@@ -447,33 +445,32 @@ func extractBuildConfigurationListTitles(_ projectText: String) -> Dictionary<St
 func extractGroupTitles(_ projectText: String) -> Dictionary<String, String> {
   var titleMap = Dictionary<String, String>()
   var inGroupSection = false
-  projectText.enumerateLines(invoking: { (line, stop) in
+  for line in projectText.components(separatedBy: CharacterSet.newlines) {
     if !inGroupSection {
       if line.contains("PBXGroup section") {
         inGroupSection = true
       }
-      return
+      continue
     }
     
     // see if we're done
     if line.contains("PBXGroup section") {
-      stop = true
-      return
+      break
     }
     // we're in the build section, and not done, so pull apart the line
     var line = line.trimmingCharacters(in: .whitespaces)
     
     var splits = line.components(separatedBy: " /* ")
     if splits.count != 2 {
-      return
+      continue
     }
     let key = splits[0]
     line = splits[1]
     splits = line.components(separatedBy: " */")
-    if splits.count != 2 { return }
+    if splits.count != 2 { continue }
     let title = splits[0]
     titleMap[key] = title
-  })
+  }
   
   return titleMap
 }
@@ -483,33 +480,32 @@ func extractGroupTitles(_ projectText: String) -> Dictionary<String, String> {
 func extractFileTitles(_ projectText: String) -> Dictionary<String, String> {
   var titleMap = Dictionary<String, String>()
   var inFileSection = false
-  projectText.enumerateLines(invoking: { (line, stop) in
+  for line in projectText.components(separatedBy: CharacterSet.newlines) {
     if !inFileSection {
       if line.contains("PBXFileReference section") {
         inFileSection = true
       }
-      return
+      continue
     }
     
     // see if we're done
     if line.contains("PBXFileReference section") {
-      stop = true
-      return
+      break
     }
     // we're in the build section, and not done, so pull apart the line
     var line = line.trimmingCharacters(in: .whitespaces)
     var splits = line.components(separatedBy: " */")
-    if splits.count != 2 { return }
+    if splits.count != 2 { continue }
     line = splits[0]
     splits = line.components(separatedBy: " /* ")
-    if splits.count != 2 { return }
+    if splits.count != 2 { continue }
     line = splits[0]
     let title = splits[1]
     splits = line.components(separatedBy: " = ")
-    if splits.count != 1 { return }
+    if splits.count != 1 { continue }
     let key = splits[0]
     titleMap[key] = title
-  })
+  }
   
   return titleMap
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,4 @@
+import XCTest
+
+// tests arn't linux compatible yet
+XCTMain([])


### PR DESCRIPTION
This PR makes it possible to build and run xcprojectlint in a Linux environment. The following steps were necessary to achieve this:
* add required Tests/LinuxMain.swift. This file is empty for now because the tests using `Bundle(for aClass:)` which is [unimplemented](https://github.com/apple/swift-corelibs-foundation/blob/1da6fc8ccbce77bfc4cc4fffa6de260ee8589708/Foundation/Bundle.swift#L57).
* remove of all `import Darwin` because it's not available on Linux. Why was this import added in the first place?
* replace NSDictionary contort with a simple cast. I'm not sure why this is necessary, the tests were green after I replaced it though.
* replace all `enumerateLinesUsingBlock(:)` calls with `components(separatedBy: CharacterSet.newlines)`. The former uses `enumerateStrings(:)` which is [unimplemented](https://github.com/apple/swift-corelibs-foundation/blob/1da6fc8ccbce77bfc4cc4fffa6de260ee8589708/Foundation/NSString.swift#L788)

# Motivation
I like to integrate xcprojectlint into a Docker based CI workflow. Therefore it should be buildable on Linux with the open source Foundation framework.

This is how a Dockerfile would look like:
```
FROM norionomura/swift:411
LABEL maintainer "Steffen Matthischke <steffen.matthischke@gmail.com>"

ENV BRANCH="linux"

RUN git clone --branch $BRANCH https://github.com/HeEAaD/xcprojectlint.git && \
    cd xcprojectlint && \
    swift package update && \
    swift build --configuration release && \
    mv `swift build --configuration release --show-bin-path`/xcprojectlint /usr/bin && \
    cd .. && \
    rm -rf xcprojectlint

# Print Installed xcprojectlint Version
RUN xcprojectlint --version
CMD ["xcprojectlint"]
```

A run would look like this:
```
docker run -v `pwd`:`pwd` -w`pwd` xcprojectlint:latest xcprojectlint --report warning --project TestData/Bad.xcodeproj --validations empty-groups
```