### PR TITLE
aligned "Actual:" to "Expected:"

### DIFF
--- a/Sources/xcprojectlint-package/EnsureAlphaOrder.swift
+++ b/Sources/xcprojectlint-package/EnsureAlphaOrder.swift
@@ -41,7 +41,7 @@ private func validateThisGroup(_ id: String, title: String, project: Project, er
   
   let matches = allNames == sortedArray
   if !matches {
-    let errStr = "\(errorReporter.reportKind.logEntry) Xcode folder “\(pathToParent)/\(title)” has out-of-order children.\nExpected: \(sortedArray)\nActual:\(allNames)"
+    let errStr = "\(errorReporter.reportKind.logEntry) Xcode folder “\(pathToParent)/\(title)” has out-of-order children.\nExpected: \(sortedArray)\nActual:   \(allNames)"
     print(errStr)
   }
   


### PR DESCRIPTION
Added spacing. It is much more easier to compare 'actual' and 'expected' if the following info is aligned to the same offset.

Compare these two:

old:
```
Expected: ["Snapfile", "SnapshotHelper.h", "SnapshotHelper.m"]
Actual: ["SnapshotHelper.h", "SnapshotHelper.m", "Snapfile"]
```

new:
```
Expected: ["Snapfile", "SnapshotHelper.h", "SnapshotHelper.m"]
Actual:   ["SnapshotHelper.h", "SnapshotHelper.m", "Snapfile"]
```
(see the alignment of the opening `[`)