### PR TITLE
Update Makefile for Homebrew Formula

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build:
 	swift build
 
 release:
-	swift build --configuration release
+	swift build --configuration release --disable-sandbox --build-path "$(BUILDDIR)"
 
 install: release
 	@install -d "$(bindir)" "$(libdir)"

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@
 # https://stackoverflow.com/a/47243701
 # which came with the above license
 
+prefix ?= /usr/local
+bindir ?= $(prefix)/bin
+libdir ?= $(prefix)/lib
+
+REPODIR = $(shell pwd)
+BUILDDIR = $(REPODIR)/.build
+
 EXECUTABLE_DIRECTORY = ./.build/x86_64-apple-macosx/debug
 TEST_RESOURCES_DIRECTORY = ./.build/x86_64-apple-macosx/debug/xcprojectlintPackageTests.xctest/Contents/Resources/
 
@@ -31,6 +38,10 @@ build:
 
 release:
 	swift build --configuration release
+
+install: release
+	@install -d "$(bindir)" "$(libdir)"
+	@install "$(BUILDDIR)/release/xcprojectlint" "$(bindir)"
 
 copyTestResources: build
 	mkdir -p ${TEST_RESOURCES_DIRECTORY}
@@ -49,4 +60,4 @@ xcode:
 clean:
 	swift package reset
 
-.PHONY: run build test copyTestResources clean xcode
+.PHONY: run build install test copyTestResources clean xcode

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ install: release
 	@install -d "$(bindir)" "$(libdir)"
 	@install "$(BUILDDIR)/release/xcprojectlint" "$(bindir)"
 
+uninstall:
+	@rm -rf "$(bindir)/xcprojectlint"
+
 copyTestResources: build
 	mkdir -p ${TEST_RESOURCES_DIRECTORY}
 	cp -r TestData ${TEST_RESOURCES_DIRECTORY}
@@ -60,4 +63,4 @@ xcode:
 clean:
 	swift package reset
 
-.PHONY: run build install test copyTestResources clean xcode
+.PHONY: run build install uninstall test copyTestResources clean xcode


### PR DESCRIPTION
This PR makes two changes in the service of supporting installation via Homebrew (#8):

First, it adds `install` and `uninstall` targets to the Makefile.

Second, it updates the `release` target to disable Sandbox when executing subprocesses, which is necessary when building executables to be installed system-wide. The `swift build` command is also updated to set an explicit build path, to guarantee that the `install` command continues to work if Swift Package Manager changes its default build location. 

I've created a Homebrew formula based on my fork here: https://github.com/NSHipster/homebrew-formulae/blob/master/Formula/xcprojectlint.rb.

You can try it for yourself by running the following command:

```terminal
$ brew install nshipster/formulae/xcprojectlint
```