### PR TITLE
Add "wrapLines" setting to list of offenders

### DIFF
--- a/Sources/xcprojectlint-package/CheckForWhitespaceSpecifications.swift
+++ b/Sources/xcprojectlint-package/CheckForWhitespaceSpecifications.swift
@@ -26,6 +26,7 @@ public func checkForWhiteSpaceSpecifications(_ project: Project, errorReporter: 
       group.tabWidth.map(toGroupError(group.id, "tabWidth")),
       group.indentWidth.map(toGroupError(group.id, "indentWidth")),
       group.usesTabs.map(toGroupError(group.id, "usesTabs")),
+      group.wrapsLines.map(toGroupError(group.id, "wrapsLines")),
     ].compactMap { $0 }
   }
 
@@ -40,14 +41,11 @@ public func checkForWhiteSpaceSpecifications(_ project: Project, errorReporter: 
       fileReference.tabWidth.map(toFileError(fileReference, "tabWidth")),
       fileReference.indentWidth.map(toFileError(fileReference, "indentWidth")),
       fileReference.lineEnding.map(toFileError(fileReference, "lineEnding")),
+      fileReference.wrapsLines.map(toFileError(fileReference, "wrapsLines")),
     ].compactMap { $0 }
   }
 
   let allErrors = groupsErrors + fileReferenceErrors
-
-  for error in allErrors {
-    ErrorReporter.report(error)
-  }
-
+  allErrors.forEach(ErrorReporter.report)
   return allErrors.isEmpty ? EX_OK : errorReporter.reportKind.returnType
 }

--- a/Sources/xcprojectlint-package/ProjectParser.swift
+++ b/Sources/xcprojectlint-package/ProjectParser.swift
@@ -164,7 +164,8 @@ public struct FileReference: TitledNode {
   public let debugDescription: String
   public let indentWidth: String?
   public let tabWidth: String?
-
+  public let wrapsLines: String?
+    
   init(key: String, value: [String: Any], title: String, projectPath _: String) {
     identifyUnparsedKeys(value, knownKeys: ["path", "name", "explicitFileType", "lastKnownFileType", "sourceTree", "fileEncoding", "lineEnding", "xcLanguageSpecificationIdentifier", "includeInIndex", "indentWidth", "tabWidth"])
     self.title = title
@@ -180,6 +181,7 @@ public struct FileReference: TitledNode {
     includeInIndex = (value["includeInIndex"] as? String) == "1"
     indentWidth = value["indentWidth"] as? String
     tabWidth = value["tabWidth"] as? String
+    wrapsLines = value["wrapsLines"] as? String
 
     debugDescription = "\(title) (\(id))"
   }
@@ -214,6 +216,7 @@ public struct Group: TitledNode {
   public let indentWidth: String?
   public let tabWidth: String?
   public let usesTabs: String?
+  public let wrapsLines: String?
 
   init(key: String, value: [String: Any], title: String) {
     identifyUnparsedKeys(value, knownKeys: ["name", "path", "sourceTree", "children", "indentWidth", "tabWidth", "usesTabs"])
@@ -226,6 +229,7 @@ public struct Group: TitledNode {
     indentWidth = value["indentWidth"] as? String
     tabWidth = value["tabWidth"] as? String
     usesTabs = value["usesTabs"] as? String
+    wrapsLines = value["wrapsLines"] as? String
 
     debugDescription = title
   }

--- a/TestData/Bad.xcodeproj/project.pbxproj
+++ b/TestData/Bad.xcodeproj/project.pbxproj
@@ -30,8 +30,8 @@
 		7819B10A22F4819E008F36CB /* BadUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BadUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		78BBAB5122FDA2E400FE1D61 /* BadUnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BadUnitTests.swift; sourceTree = "<group>"; };
 		D2A90D0F2032181600EBA6AA /* ThisFileIsMissing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThisFileIsMissing.swift; sourceTree = "<group>"; };
-		D2A90D132032190A00EBA6AA /* First.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = First.swift; sourceTree = "<group>"; };
-		D2A90D152032191600EBA6AA /* Second.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 5; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Second.swift; sourceTree = "<group>";  tabWidth = 5; };
+		D2A90D132032190A00EBA6AA /* First.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = First.swift; sourceTree = "<group>"; wrapsLines = 1; };
+		D2A90D152032191600EBA6AA /* Second.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 5; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Second.swift; sourceTree = "<group>"; tabWidth = 5; wrapsLines = 1; };
 		D2CAE8732031EE5F00F76063 /* Bad */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Bad; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CAE8762031EE5F00F76063 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D2CAE89C2032142D00F76063 /* ThisFileIsMisplaced.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ThisFileIsMisplaced.swift; path = ../MisplacdFile/ThisFileIsMisplaced.swift; sourceTree = "<group>"; };
@@ -88,6 +88,7 @@
 			);
 			path = ItemsOutOfOrder;
 			sourceTree = "<group>";
+			wrapsLines = 1;
 		};
 		D2A90D18203219FC00EBA6AA /* ThisGroupIsEmpty */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
- Update `ProjectParser` to read `wrapLines` attribute for groups and files
- Update rule for "no local whitespace specifications" with `wrapLines` check
- Update test data
