### PR TITLE
Improve Testability and Reporting

### DIFF
--- a/Sources/xcprojectlint-package/DiskLayoutMatchesProject.swift
+++ b/Sources/xcprojectlint-package/DiskLayoutMatchesProject.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-private func recurseForMisplacedFiles(_ groups: [String], project: Project, errors: Set<String>, errorReporter: ErrorReporter) -> Set<String> {
+private func recurseForMisplacedFiles(_ groups: [String], project: Project, errors: Set<String>, logEntry: String) -> Set<String> {
   var errors = errors
   for child in groups {
     if let group = project.groups[child] {
@@ -22,15 +22,15 @@ private func recurseForMisplacedFiles(_ groups: [String], project: Project, erro
         continue
       }
       if group.name != nil {
-        let errStr = "\(errorReporter.reportKind.logEntry) Folder “\(group.title)” (\(group.id)) is misplaced on disk, or wrong kind of reference.\n"
+        let errStr = "\(logEntry) Folder “\(group.title)” (\(group.id)) is misplaced on disk, or wrong kind of reference.\n"
         errors.insert(errStr)
         // Once we've found a detached parent, none of the children need to be looked at; they're detached, too.
         continue
       }
-      errors = recurseForMisplacedFiles(group.children, project: project, errors: errors, errorReporter: errorReporter)
+      errors = recurseForMisplacedFiles(group.children, project: project, errors: errors, logEntry: logEntry)
     } else if let file = project.fileReferences[child] {
       if file.name != nil {
-        let errStr = "\(errorReporter.reportKind.logEntry) File “\(file.title)” (\(file.id)) is misplaced on disk, or wrong kind of reference.\n"
+        let errStr = "\(logEntry) File “\(file.title)” (\(file.id)) is misplaced on disk, or wrong kind of reference.\n"
         errors.insert(errStr)
       }
     }
@@ -46,27 +46,18 @@ private func groupExcluded(_ group: Group) -> Bool {
 
 var skkipFolders: [String]?
 
-public func diskLayoutMatchesProject(_ project: Project, errorReporter: ErrorReporter, skipFolders: [String]?) -> Int32 {
+public func diskLayoutMatchesProject(_ project: Project, logEntry: String, skipFolders: [String]?) -> Report {
   skkipFolders = skipFolders
-  var result = EX_DATAERR
-  if let proj = project.projectNodes.first {
-    let mainGroup = proj.mainGroup
-    let group = project.groups[mainGroup]
-
-    let errors = Set<String>()
-    if let children = group?.children {
-      let results = recurseForMisplacedFiles(children, project: project, errors: errors, errorReporter: errorReporter).sorted()
-
-      if results.count > 0 {
-        result = errorReporter.reportKind.returnType
-        for error in results {
-          ErrorReporter.report(error)
-        }
-      } else {
-        result = EX_OK
-      }
-    }
+  guard let proj = project.projectNodes.first,
+    let children = project.groups[proj.mainGroup]?.children else {
+      return .invalidInput
   }
-
-  return result
+  
+  let errors = recurseForMisplacedFiles(
+    children,
+    project: project,
+    errors: Set<String>(),
+    logEntry: logEntry
+  )
+  return errors.isEmpty ? .passed : .failed(errors: errors.sorted())
 }

--- a/Sources/xcprojectlint-package/ErrorReporter.swift
+++ b/Sources/xcprojectlint-package/ErrorReporter.swift
@@ -23,16 +23,28 @@ public struct ErrorReporter {
     self.reportKind = reportKind
   }
 
-  public func report(_ error: Error) {
+  public func report(_ error: Error) -> String {
     // NOTE: The spaces around the error: portion of the screen are required with Xcode 8.3. Without them, no output gets reported in the Issue Navigator.
-    let errStr = "\(pbxprojPath):0: \(reportKind.logEntry) \(error.localizedDescription)\n"
-    ErrorReporter.report(errStr)
+    return "\(pbxprojPath):0: \(reportKind.logEntry) \(error.localizedDescription)\n"
   }
 
   public static func report(_ errorString: String) {
     let handle = FileHandle.standardError
     if let data = errorString.data(using: .utf8) {
       handle.write(data)
+    }
+  }
+}
+
+extension ErrorReporter {
+  public func toStatusCode(from checkReport: Report) -> Int32 {
+    switch checkReport {
+    case .invalidInput:
+      return EX_DATAERR
+    case .failed:
+      return reportKind.returnType
+    case .passed:
+      return EX_OK
     }
   }
 }

--- a/Sources/xcprojectlint-package/Report.swift
+++ b/Sources/xcprojectlint-package/Report.swift
@@ -15,6 +15,19 @@
 import Foundation
 import SPMUtility
 
+public enum Report: Equatable {
+  case invalidInput
+  case failed(errors: [String])
+  case passed
+  
+  public var errors: [String] {
+    guard case let .failed(errors) = self else {
+      return []
+    }
+    return errors
+  }
+}
+
 public enum ReportKind: StringEnumArgument {
   case warning
   case error

--- a/Tests/xcprojectlint-packageTests/Bundle.swift
+++ b/Tests/xcprojectlint-packageTests/Bundle.swift
@@ -26,15 +26,15 @@ extension Bundle {
     return Bundle(for: BundleLocator.self)
   }
 
+  var testDataRoot: URL {
+    return bundleURL
+    .appendingPathComponent("Contents")
+    .appendingPathComponent("Resources")
+    .appendingPathComponent("TestData")
+  }
+  
   func testData(_ testType: TypeOfData = .bad) -> String {
     let pathSuffix = testType == .bad ? "Bad.xcodeproj" : "Good.xcodeproj"
-
-    let testDataURL = bundleURL
-      .appendingPathComponent("Contents")
-      .appendingPathComponent("Resources")
-      .appendingPathComponent("TestData")
-      .appendingPathComponent(pathSuffix)
-
-    return testDataURL.path
+    return testDataRoot.appendingPathComponent(pathSuffix).path
   }
 }

--- a/Tests/xcprojectlint-packageTests/DiskLayoutMatchesProjectTests.swift
+++ b/Tests/xcprojectlint-packageTests/DiskLayoutMatchesProjectTests.swift
@@ -22,7 +22,12 @@ final class DiskLayoutMatchesProjectTests: XCTestCase {
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
 
-      XCTAssertEqual(diskLayoutMatchesProject(project, errorReporter: errorReporter, skipFolders: ["Products"]), EX_OK)
+      let report = diskLayoutMatchesProject(
+        project,
+        logEntry: errorReporter.reportKind.logEntry,
+        skipFolders: ["Products"]
+      )
+      XCTAssertEqual(report, .passed)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialize test")
@@ -34,8 +39,16 @@ final class DiskLayoutMatchesProjectTests: XCTestCase {
       let testData = Bundle.test.testData()
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-
-      XCTAssertEqual(diskLayoutMatchesProject(project, errorReporter: errorReporter, skipFolders: ["Products"]), EX_SOFTWARE)
+      let expectedErrors = [
+        "error: File “ThisFileIsMisplaced.swift” (D2CAE89C2032142D00F76063) is misplaced on disk, or wrong kind of reference.\n",
+        "error: Folder “BadUnitTests” (78BBAB5022FDA2E400FE1D61) is misplaced on disk, or wrong kind of reference.\n"
+      ]
+      let report = diskLayoutMatchesProject(
+        project,
+        logEntry: errorReporter.reportKind.logEntry,
+        skipFolders: ["Products"]
+      )
+      XCTAssertEqual(report.errors, expectedErrors)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialize test")

--- a/Tests/xcprojectlint-packageTests/FilesExistOnDiskTests.swift
+++ b/Tests/xcprojectlint-packageTests/FilesExistOnDiskTests.swift
@@ -21,8 +21,8 @@ final class FilesExistOnDiskTests: XCTestCase {
       let testData = Bundle.test.testData(.good)
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-
-      XCTAssertEqual(filesExistOnDisk(project, errorReporter: errorReporter), EX_OK)
+      let report = filesExistOnDisk(project, logEntry: errorReporter.reportKind.logEntry)
+      XCTAssertEqual(report, .passed)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialize test")
@@ -34,8 +34,11 @@ final class FilesExistOnDiskTests: XCTestCase {
       let testData = Bundle.test.testData()
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-
-      XCTAssertEqual(filesExistOnDisk(project, errorReporter: errorReporter), EX_SOFTWARE)
+      let expectedErrors = [
+        "\(project.url.path):0: error: Bad/MissingFile references files that are not on disk.\n"
+      ]
+      let report = filesExistOnDisk(project, logEntry: errorReporter.reportKind.logEntry)
+      XCTAssertEqual(report.errors, expectedErrors)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialize test")

--- a/Tests/xcprojectlint-packageTests/InternalProjectSettingsTests.swift
+++ b/Tests/xcprojectlint-packageTests/InternalProjectSettingsTests.swift
@@ -21,21 +21,38 @@ final class InternalProjectSettingsTests: XCTestCase {
       let testData = Bundle.test.testData(.good)
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-
-      XCTAssertEqual(checkForInternalProjectSettings(project, errorReporter: errorReporter), EX_OK)
+      let report = checkForInternalProjectSettings(
+        project,
+        pbxprojPath: errorReporter.pbxprojPath,
+        logEntry: errorReporter.reportKind.logEntry
+      )
+      XCTAssertEqual(report, .passed)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialise test")
     }
   }
-
+  
   func test_containsInternalProjectSettings_returnsError() {
     do {
       let testData = Bundle.test.testData()
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-
-      XCTAssertEqual(checkForInternalProjectSettings(project, errorReporter: errorReporter), EX_SOFTWARE)
+      let projectPath = project.url.path
+      let expectedErrors = [
+        "\(projectPath):251: error: Debug has settings defined at the project level.\n",
+        "\(projectPath):271: error: Release has settings defined at the project level.\n",
+        "\(projectPath):290: error: Debug has settings defined at the project level.\n",
+        "\(projectPath):347: error: Release has settings defined at the project level.\n",
+        "\(projectPath):396: error: Debug has settings defined at the project level.\n",
+        "\(projectPath):406: error: Release has settings defined at the project level.\n"
+      ]
+      let report = checkForInternalProjectSettings(
+        project,
+        pbxprojPath: errorReporter.pbxprojPath,
+        logEntry: errorReporter.reportKind.logEntry
+      )
+      XCTAssertEqual(report.errors, expectedErrors)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialize test")

--- a/Tests/xcprojectlint-packageTests/ItemsInAlphaOrderTests.swift
+++ b/Tests/xcprojectlint-packageTests/ItemsInAlphaOrderTests.swift
@@ -21,21 +21,25 @@ final class ItemsInAlphaOrderTests: XCTestCase {
       let testData = Bundle.test.testData(.good)
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-
-      XCTAssertEqual(ensureAlphaOrder(project, errorReporter: errorReporter), EX_OK)
+      let report = ensureAlphaOrder(project, logEntry: errorReporter.reportKind.logEntry)
+      XCTAssertEqual(report, .passed)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialise test")
     }
   }
-
+  
   func test_unorderedGroup_returnsError() {
     do {
       let testData = Bundle.test.testData()
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-
-      XCTAssertEqual(ensureAlphaOrder(project, errorReporter: errorReporter), EX_SOFTWARE)
+      let expectedErrors = [
+        "error: Xcode folder “Bad/ItemsOutOfOrder” has out-of-order children.\nExpected: [\"First.swift\", \"Second.swift\"]\nActual:   [\"Second.swift\", \"First.swift\"]",
+        "error: Xcode folder “/Bad” has out-of-order children.\nExpected: [\"ItemsOutOfOrder\", \"MisplacedFile\", \"MissingFile\", \"ThisGroupIsEmpty\", \"main.swift\"]\nActual:   [\"ItemsOutOfOrder\", \"main.swift\", \"MisplacedFile\", \"MissingFile\", \"ThisGroupIsEmpty\"]"
+      ]
+      let report = ensureAlphaOrder(project, logEntry: errorReporter.reportKind.logEntry)
+      XCTAssertEqual(report.errors, expectedErrors)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialize test")

--- a/Tests/xcprojectlint-packageTests/NoDanglingFilesTests.swift
+++ b/Tests/xcprojectlint-packageTests/NoDanglingFilesTests.swift
@@ -21,8 +21,8 @@ class NoDanglingSourceFilesTests: XCTestCase {
       let testData = Bundle.test.testData(.good)
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-
-      XCTAssertEqual(checkForDanglingSourceFiles(project, errorReporter: errorReporter), EX_OK)
+      let report = checkForDanglingSourceFiles(project, logEntry: errorReporter.reportKind.logEntry)
+      XCTAssertEqual(report, .passed)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialise test")
@@ -32,10 +32,14 @@ class NoDanglingSourceFilesTests: XCTestCase {
   func test_danglingSourceFiles_returnsError() {
     do {
       let testData = Bundle.test.testData()
+      let testDataPath = Bundle.test.testDataRoot.path
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-
-      XCTAssertEqual(checkForDanglingSourceFiles(project, errorReporter: errorReporter), EX_SOFTWARE)
+      let expectedErrors = [
+        "\(testDataPath)/BadUnitTests/DanglingFile/BadUnitTests.swift:0: error: BadUnitTests.swift is not added to any target.\n"
+      ]
+      let report = checkForDanglingSourceFiles(project, logEntry: errorReporter.reportKind.logEntry)
+      XCTAssertEqual(report.errors, expectedErrors)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialize test")

--- a/Tests/xcprojectlint-packageTests/NoEmptyGroupsTests.swift
+++ b/Tests/xcprojectlint-packageTests/NoEmptyGroupsTests.swift
@@ -21,8 +21,8 @@ final class NoEmptyGroupsTests: XCTestCase {
       let testData = Bundle.test.testData(.good)
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-
-      XCTAssertEqual(noEmptyGroups(project, errorReporter: errorReporter), EX_OK)
+      let report = noEmptyGroups(project, logEntry: errorReporter.reportKind.logEntry)
+      XCTAssertEqual(report, .passed)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialise test")
@@ -34,8 +34,9 @@ final class NoEmptyGroupsTests: XCTestCase {
       let testData = Bundle.test.testData()
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-
-      XCTAssertEqual(noEmptyGroups(project, errorReporter: errorReporter), EX_SOFTWARE)
+      let expectedErrors = ["error: Xcode folder “Bad/ThisGroupIsEmpty” has no children."]
+      let report = noEmptyGroups(project, logEntry: errorReporter.reportKind.logEntry)
+      XCTAssertEqual(report.errors, expectedErrors)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialize test")

--- a/Tests/xcprojectlint-packageTests/WhiteSpaceSpecificationTests.swift
+++ b/Tests/xcprojectlint-packageTests/WhiteSpaceSpecificationTests.swift
@@ -22,7 +22,8 @@ final class WhiteSpaceSpecificationTests: XCTestCase {
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
 
-      XCTAssertEqual(checkForWhiteSpaceSpecifications(project, errorReporter: errorReporter), EX_OK)
+      let report = checkForWhiteSpaceSpecifications(project, logEntry: errorReporter.reportKind.logEntry)
+      XCTAssertEqual(report, .passed)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialize test")
@@ -32,10 +33,23 @@ final class WhiteSpaceSpecificationTests: XCTestCase {
   func test_whiteSpaceSpecifiersArePresent_returnsError() {
     do {
       let testData = Bundle.test.testData()
+      let testDataPath = Bundle.test.testDataRoot.path
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
 
-      XCTAssertEqual(checkForWhiteSpaceSpecifications(project, errorReporter: errorReporter), EX_SOFTWARE)
+      let report = checkForWhiteSpaceSpecifications(project, logEntry: errorReporter.reportKind.logEntry)
+      let expectedErrors = [
+        "error: Group item (D2A90D172032191C00EBA6AA) contains white space specification of \'wrapsLines\'.\n ",
+        "error: Group item (D2CAE8752031EE5F00F76063) contains white space specification of \'indentWidth\'.\n ",
+        "error: Group item (D2CAE8752031EE5F00F76063) contains white space specification of \'tabWidth\'.\n ",
+        "error: Group item (D2CAE8752031EE5F00F76063) contains white space specification of \'usesTabs\'.\n ",
+        "\(testDataPath)/Bad/ItemsOutOfOrder/First.swift:0:error: File “First.swift” (D2A90D132032190A00EBA6AA) contains white space specification of \'wrapsLines\'.\n",
+        "\(testDataPath)/Bad/ItemsOutOfOrder/Second.swift:0:error: File “Second.swift” (D2A90D152032191600EBA6AA) contains white space specification of \'indentWidth\'.\n",
+        "\(testDataPath)/Bad/ItemsOutOfOrder/Second.swift:0:error: File “Second.swift” (D2A90D152032191600EBA6AA) contains white space specification of \'lineEnding\'.\n",
+        "\(testDataPath)/Bad/ItemsOutOfOrder/Second.swift:0:error: File “Second.swift” (D2A90D152032191600EBA6AA) contains white space specification of \'tabWidth\'.\n",
+        "\(testDataPath)/Bad/ItemsOutOfOrder/Second.swift:0:error: File “Second.swift” (D2A90D152032191600EBA6AA) contains white space specification of \'wrapsLines\'.\n"
+      ]
+      XCTAssertEqual(report.errors, expectedErrors)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialize test")


### PR DESCRIPTION
## Improve Testability and Reporting

- Introduce `Report` type which describes result of each rule check
- Return `Report` from rule checks instead of opaque `Int32`, thus enabling testability 
- Provide test coverage for each check. Assert equality on `expected` and `actual` reports and associated error messages
- Decouple rule checks from execution environment. Make them lose knowledge of console, status codes or reporting system
- Report errors and reduce script exit code in a consolidated way in `main.swift`

*My goal was to make as little changes to rules logic as possible. Most of changes there are connected to change of return type and not to the rule logic itself.* 

