### PR TITLE
Fix error when parsing build phase with empty Input/Output Files

### DIFF
--- a/Sources/xcprojectlint-package/ProjectParser.swift
+++ b/Sources/xcprojectlint-package/ProjectParser.swift
@@ -364,8 +364,8 @@ public struct ShellScriptBuildPhase: Identifiable, FileContainer, CustomDebugStr
     name = value["name"] as? String ?? "Untitled"
     runOnlyForDeploymentPostprocessing = value.string(forKey: "runOnlyForDeploymentPostprocessing", container: "(type(of: self))") == "1"
     shellPath = value.string(forKey: "shellPath", container: "(type(of: self))")
-    inputPaths = value["inputPaths"] as! [String]
-    outputPaths = value["outputPaths"] as! [String]
+    inputPaths = value["inputPaths"] as? [String] ?? []
+    outputPaths = value["outputPaths"] as? [String] ?? []
     shellScript = value.string(forKey: "shellScript", container: "(type(of: self))")
     buildActionMask = value.string(forKey: "buildActionMask", container: "(type(of: self))")
 


### PR DESCRIPTION
Hello.

I fixed an issue in xcprojectlint. If a Build Phase of a Target has empty Input Files or Output Files xcprojectlint fails with this error:
`zsh: illegal hardware instruction   --report error --validations files-exist-on-disk items-in-alpha-order  
`
I replaced force unwrap operator with ?? operator.