### PR TITLE
Feature: Add --sort-by-name option for items-in-alpha-order validation

### DIFF
--- a/Sources/xcprojectlint-package/Usage.swift
+++ b/Sources/xcprojectlint-package/Usage.swift
@@ -24,4 +24,10 @@ public struct Usage {
                          Useful for Frameworks, Products, and/or source trees
                          that aren’t chidren to the project file
     """
+
+  public static let sortByName =
+    """
+    Sort order for `items-in-alpha-order` is the same as Xcode's
+                         `Sort by Name` Project Navigator command
+    """
 }

--- a/Sources/xcprojectlint/main.swift
+++ b/Sources/xcprojectlint/main.swift
@@ -92,7 +92,7 @@ func main() -> Int32 {
             case .filesExistOnDisk:
               return filesExistOnDisk(project, logEntry: logEntry)
             case .itemsInAlphaOrder:
-                return ensureAlphaOrder(project, logEntry: logEntry, sortByName: sortByName ?? false)
+              return ensureAlphaOrder(project, logEntry: logEntry, sortByName: sortByName ?? false)
             case .noDanglingSourceFiles:
               return checkForDanglingSourceFiles(project, logEntry: logEntry)
             case .noEmptyGroups:

--- a/Sources/xcprojectlint/main.swift
+++ b/Sources/xcprojectlint/main.swift
@@ -35,6 +35,7 @@ func main() -> Int32 {
     let validationsArg: OptionArgument<[Validation]> = parser.add(option: "--validations", kind: [Validation].self, usage: Validation.usage)
     let projectArg: OptionArgument<PathArgument> = parser.add(option: "--project", kind: PathArgument.self, usage: Usage.project)
     let skipFoldersArg: OptionArgument<[String]> = parser.add(option: "--skip-folders", kind: [String].self, usage: Usage.skipFolders)
+    let sortByNameArg: OptionArgument<Bool> = parser.add(option: "--sort-by-name", kind: Bool.self, usage: Usage.sortByName)
 
     // The first argument is always the executable, so drop it
     var processArgs = ProcessInfo.processInfo.arguments.dropFirst()
@@ -74,6 +75,7 @@ func main() -> Int32 {
       let proj = args.get(projectArg) else { return EX_SOFTWARE }
 
     let skipFolders = args.get(skipFoldersArg)
+    let sortByName = args.get(sortByNameArg)
     if validations.last == .all {
       validations = Validation.allValidations()
     }
@@ -90,7 +92,7 @@ func main() -> Int32 {
             case .filesExistOnDisk:
               return filesExistOnDisk(project, logEntry: logEntry)
             case .itemsInAlphaOrder:
-              return ensureAlphaOrder(project, logEntry: logEntry)
+                return ensureAlphaOrder(project, logEntry: logEntry, sortByName: sortByName ?? false)
             case .noDanglingSourceFiles:
               return checkForDanglingSourceFiles(project, logEntry: logEntry)
             case .noEmptyGroups:

--- a/Tests/xcprojectlint-packageTests/ItemsInAlphaOrderTests.swift
+++ b/Tests/xcprojectlint-packageTests/ItemsInAlphaOrderTests.swift
@@ -21,24 +21,56 @@ final class ItemsInAlphaOrderTests: XCTestCase {
       let testData = Bundle.test.testData(.good)
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-      let report = ensureAlphaOrder(project, logEntry: errorReporter.reportKind.logEntry)
+      let report = ensureAlphaOrder(project, logEntry: errorReporter.reportKind.logEntry, sortByName: false)
       XCTAssertEqual(report, .passed)
     } catch {
       print(error.localizedDescription)
       XCTFail("Failed to initialise test")
     }
   }
-  
+
+  func test_sortedGroup_returnsErrors_whenExpectingSortByName() {
+    do {
+      let testData = Bundle.test.testData(.good)
+      let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
+      let project = try Project(testData, errorReporter: errorReporter)
+      let report = ensureAlphaOrder(project, logEntry: errorReporter.reportKind.logEntry, sortByName: true)
+      let expectedErrors = [
+        """
+        error: Xcode folder “/Good” has out-of-order children.
+        Expected: ["AppDelegate.swift", "Assets.xcassets", "Info.plist", "main.swift", "ViewController.swift", "xcconfigs"]
+        Actual:   ["xcconfigs", "AppDelegate.swift", "Assets.xcassets", "Info.plist", "main.swift", "ViewController.swift"]
+
+        """,
+      ]
+
+      XCTAssertEqual(report.errors, expectedErrors)
+    } catch {
+      print(error.localizedDescription)
+      XCTFail("Failed to initialise test")
+    }
+  }
+
   func test_unorderedGroup_returnsError() {
     do {
       let testData = Bundle.test.testData()
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
       let expectedErrors = [
-        "error: Xcode folder “Bad/ItemsOutOfOrder” has out-of-order children.\nExpected: [\"First.swift\", \"Second.swift\"]\nActual:   [\"Second.swift\", \"First.swift\"]",
-        "error: Xcode folder “/Bad” has out-of-order children.\nExpected: [\"ItemsOutOfOrder\", \"MisplacedFile\", \"MissingFile\", \"ThisGroupIsEmpty\", \"main.swift\"]\nActual:   [\"ItemsOutOfOrder\", \"main.swift\", \"MisplacedFile\", \"MissingFile\", \"ThisGroupIsEmpty\"]"
+        """
+        error: Xcode folder “Bad/ItemsOutOfOrder” has out-of-order children.
+        Expected: ["First.swift", "Second.swift"]
+        Actual:   ["Second.swift", "First.swift"]
+
+        """,
+        """
+        error: Xcode folder “/Bad” has out-of-order children.
+        Expected: ["ItemsOutOfOrder", "MisplacedFile", "MissingFile", "ThisGroupIsEmpty", "main.swift"]
+        Actual:   ["ItemsOutOfOrder", "main.swift", "MisplacedFile", "MissingFile", "ThisGroupIsEmpty"]
+
+        """,
       ]
-      let report = ensureAlphaOrder(project, logEntry: errorReporter.reportKind.logEntry)
+      let report = ensureAlphaOrder(project, logEntry: errorReporter.reportKind.logEntry, sortByName: false)
       XCTAssertEqual(report.errors, expectedErrors)
     } catch {
       print(error.localizedDescription)


### PR DESCRIPTION
Resolves #22 

This PR introduces a new option to control the sort behaviour of the `items-in-alpha-order` validation.

The default sort behaviour of `items-in-alpha-order` requires that Xcode users manually sort their groups.  `xcprojectlint` should support Xcode's default behaviour.  It is a lot less effort for developers to just make use of Xcode's default Group/Folder sorting options exposed by the Project Navigator.

This PR does not change the default behaviour of `xcprojectlint` but instead introduces an option to allow the user of `xcprojectlint` to control what the sorting behaviour is for the `items-in-alpha-order` validation.