### PR TITLE
Added types to parser

### DIFF
--- a/Sources/xcprojectlint-package/ProjectParser.swift
+++ b/Sources/xcprojectlint-package/ProjectParser.swift
@@ -713,6 +713,10 @@ public class ProjectParser {
           break
         case "PBXHeadersBuildPhase":
           break
+        case "XCSwiftPackageProductDependency":
+          break
+        case "XCRemoteSwiftPackageReference":
+          break
         default:
           print("New type found: \(node)")
         }


### PR DESCRIPTION
We recognize, but do not parse `XCSwiftPackageProductDependency` and `XCRemoteSwiftPackageReference` nodes. 

Fixes #27