### PR TITLE
Migrate to SwiftToolsSupport

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "llbuild",
-        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "f1c9ad9a253cdf1aa89a7f5c99c30b4513b06ddb",
-          "version": "0.1.1"
-        }
-      },
-      {
-        "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
-        "state": {
-          "branch": null,
-          "revision": "8656a25cb906c1896339f950ac960ee1b4fe8034",
-          "version": "0.4.0"
+          "revision": "98a5916a811fcaaed770f1ed812e9405be762945",
+          "version": "0.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.1.0"),
   ],
   targets: [
     .target(
@@ -39,7 +39,7 @@ let package = Package(
     ),
     .target(
       name: "xcprojectlint-package",
-      dependencies: ["SPMUtility"]
+      dependencies: ["SwiftToolsSupport"]
     ),
     .testTarget(
       name: "xcprojectlint-packageTests",

--- a/Sources/xcprojectlint-package/Report.swift
+++ b/Sources/xcprojectlint-package/Report.swift
@@ -13,7 +13,7 @@
  */
 
 import Foundation
-import SPMUtility
+import TSCUtility
 
 public enum Report: Equatable {
   case invalidInput

--- a/Sources/xcprojectlint-package/Validation.swift
+++ b/Sources/xcprojectlint-package/Validation.swift
@@ -13,7 +13,7 @@
  */
 
 import Foundation
-import SPMUtility
+import TSCUtility
 
 public enum Validation: String, StringEnumArgument {
   case buildSettingsExternalized = "build-settings-externalized"

--- a/Sources/xcprojectlint-package/Version.swift
+++ b/Sources/xcprojectlint-package/Version.swift
@@ -12,6 +12,6 @@
  * the License.
  */
 
-import SPMUtility
+import TSCUtility
 
 public let currentVersion = Version(0, 0, 6)

--- a/Sources/xcprojectlint/main.swift
+++ b/Sources/xcprojectlint/main.swift
@@ -12,9 +12,8 @@
  * the License.
  */
 
-import Basic
 import Foundation
-import SPMUtility
+import TSCUtility
 import xcprojectlint_package
 
 func noteSuccess() {


### PR DESCRIPTION
Recent versions of SPM have split out the utility functions into `SwiftToolsSupport`, and renamed the module to `SPMUtility`. This PR migrates to the newer interface.

Fixes issue #30