### PR TITLE
Support for skipping folders in alpha order rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ currently supports these checks:
 
 - `items-in-alpha-order`
 
-    This mode ensures the project files and folders are in proper order.
+    This mode ensures the project files and folders are in proper order. 
+    There are some occasions where you may not be able to exactly sort items
+    in specific folders (Frameworks and Products are common examples). For this,
+    there is an additional parameter you can pass: `--skip-folders`, followed by
+    a list of folders to ignore.
 
 - `no-white-space-specifications`
 

--- a/Sources/xcprojectlint-package/DiskLayoutMatchesProject.swift
+++ b/Sources/xcprojectlint-package/DiskLayoutMatchesProject.swift
@@ -40,14 +40,14 @@ private func recurseForMisplacedFiles(_ groups: [String], project: Project, erro
 
 private func groupExcluded(_ group: Group) -> Bool {
   guard let name = group.name,
-    let skipFolders = skkipFolders else { return false }
+    let skipFolders = _skipFolders else { return false }
   return skipFolders.contains(name)
 }
 
-var skkipFolders: [String]?
+private var _skipFolders: [String]?
 
 public func diskLayoutMatchesProject(_ project: Project, logEntry: String, skipFolders: [String]?) -> Report {
-  skkipFolders = skipFolders
+  _skipFolders = skipFolders
   guard let proj = project.projectNodes.first,
     let children = project.groups[proj.mainGroup]?.children else {
     return .invalidInput

--- a/Sources/xcprojectlint-package/EnsureAlphaOrder.swift
+++ b/Sources/xcprojectlint-package/EnsureAlphaOrder.swift
@@ -70,10 +70,14 @@ private func recurseLookingForOrder(_ groups: [String], project: Project, logEnt
   }
 }
 
-public func ensureAlphaOrder(_ project: Project, logEntry: String, sortByName: Bool) -> Report {
+public func ensureAlphaOrder(_ project: Project, logEntry: String, sortByName: Bool, skipFolders: [String]?) -> Report {
   guard let proj = project.projectNodes.first,
-    let children = project.groups[proj.mainGroup]?.children else {
+    var children = project.groups[proj.mainGroup]?.children else {
     return .invalidInput
+  }
+
+  if let skipFolders = skipFolders, !skipFolders.isEmpty {
+    children.removeAll { skipFolders.contains(project.groups[$0]?.name ?? "") }
   }
 
   let sortOrder: SortOrder = sortByName ? .byName : .default

--- a/Sources/xcprojectlint/main.swift
+++ b/Sources/xcprojectlint/main.swift
@@ -91,7 +91,7 @@ func main() -> Int32 {
       case .filesExistOnDisk:
         return filesExistOnDisk(project, logEntry: logEntry)
       case .itemsInAlphaOrder:
-        return ensureAlphaOrder(project, logEntry: logEntry, sortByName: sortByName ?? false)
+        return ensureAlphaOrder(project, logEntry: logEntry, sortByName: sortByName ?? false, skipFolders: skipFolders)
       case .noDanglingSourceFiles:
         return checkForDanglingSourceFiles(project, logEntry: logEntry)
       case .noEmptyGroups:

--- a/Tests/xcprojectlint-packageTests/ItemsInAlphaOrderTests.swift
+++ b/Tests/xcprojectlint-packageTests/ItemsInAlphaOrderTests.swift
@@ -21,7 +21,12 @@ final class ItemsInAlphaOrderTests: XCTestCase {
       let testData = Bundle.test.testData(.good)
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-      let report = ensureAlphaOrder(project, logEntry: errorReporter.reportKind.logEntry, sortByName: false)
+      let report = ensureAlphaOrder(
+        project,
+        logEntry: errorReporter.reportKind.logEntry,
+        sortByName: false,
+        skipFolders: nil
+      )
       XCTAssertEqual(report, .passed)
     } catch {
       print(error.localizedDescription)
@@ -34,7 +39,12 @@ final class ItemsInAlphaOrderTests: XCTestCase {
       let testData = Bundle.test.testData(.good)
       let errorReporter = ErrorReporter(pbxprojPath: testData, reportKind: .error)
       let project = try Project(testData, errorReporter: errorReporter)
-      let report = ensureAlphaOrder(project, logEntry: errorReporter.reportKind.logEntry, sortByName: true)
+      let report = ensureAlphaOrder(
+        project,
+        logEntry: errorReporter.reportKind.logEntry,
+        sortByName: true,
+        skipFolders: ["Products"]
+      )
       let expectedErrors = [
         """
         error: Xcode folder “/Good” has out-of-order children.
@@ -70,7 +80,12 @@ final class ItemsInAlphaOrderTests: XCTestCase {
 
         """,
       ]
-      let report = ensureAlphaOrder(project, logEntry: errorReporter.reportKind.logEntry, sortByName: false)
+      let report = ensureAlphaOrder(
+        project,
+        logEntry: errorReporter.reportKind.logEntry,
+        sortByName: false,
+        skipFolders: ["Products"]
+      )
       XCTAssertEqual(report.errors, expectedErrors)
     } catch {
       print(error.localizedDescription)


### PR DESCRIPTION
## Background

In some cases where a Xcode project has multiple targets, its products after compiling may not in an alphabetic order. 

The same thing happens when linking frameworks in multiple targets, and may result in a disorder of children items in `/Frameworks` folder.

## Proposal

To solve the above issues, we can enable `--skip-folders` command and let users decide which folders they want to skip during analyzing alphabetic rule. Just like what has been done for `disk-layout-matches-project`.


Hey @kalkwarf @PompeiaPaetenari 👋
Could you please have a look on this pull request? Feel free to left any comments, thanks!